### PR TITLE
Feat/3 family

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="FrameworkDetectionExcludesConfiguration">

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,7 +4,20 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="32d36446-7575-4607-9ea8-464b35441d09" name="Changes" comment="" />
+    <list default="true" id="32d36446-7575-4607-9ea8-464b35441d09" name="Changes" comment="">
+      <change afterPath="$PROJECT_DIR$/familing/src/main/java/com/pinu/familing/domain/family/dto/FamilyName.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/familing/src/main/java/com/pinu/familing/domain/family/handler/FamilyCodeHandler.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/gradle.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/gradle.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/misc.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/misc.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/familing/src/main/java/com/pinu/familing/domain/family/controller/FamilyController.java" beforeDir="false" afterPath="$PROJECT_DIR$/familing/src/main/java/com/pinu/familing/domain/family/controller/FamilyController.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/familing/src/main/java/com/pinu/familing/domain/family/entity/Family.java" beforeDir="false" afterPath="$PROJECT_DIR$/familing/src/main/java/com/pinu/familing/domain/family/entity/Family.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/familing/src/main/java/com/pinu/familing/domain/family/service/FamilyService.java" beforeDir="false" afterPath="$PROJECT_DIR$/familing/src/main/java/com/pinu/familing/domain/family/service/FamilyService.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/familing/src/main/java/com/pinu/familing/domain/user/dto/UserDto.java" beforeDir="false" afterPath="$PROJECT_DIR$/familing/src/main/java/com/pinu/familing/domain/user/dto/UserDto.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/familing/src/main/java/com/pinu/familing/domain/user/entity/User.java" beforeDir="false" afterPath="$PROJECT_DIR$/familing/src/main/java/com/pinu/familing/domain/user/entity/User.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/familing/src/main/java/com/pinu/familing/domain/user/service/UserService.java" beforeDir="false" afterPath="$PROJECT_DIR$/familing/src/main/java/com/pinu/familing/domain/user/service/UserService.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/familing/src/main/java/com/pinu/familing/global/error/ExceptionCode.java" beforeDir="false" afterPath="$PROJECT_DIR$/familing/src/main/java/com/pinu/familing/global/error/ExceptionCode.java" afterDir="false" />
+    </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -27,13 +40,31 @@
       </state>
     </system>
   </component>
+  <component name="FileTemplateManagerImpl">
+    <option name="RECENT_TEMPLATES">
+      <list>
+        <option value="JUnit5 Test Class" />
+        <option value="Record" />
+        <option value="Class" />
+      </list>
+    </option>
+  </component>
   <component name="Git.Settings">
     <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
   </component>
-  <component name="ProjectColorInfo"><![CDATA[{
-  "associatedIndex": 2
-}]]></component>
+  <component name="KubernetesApiProvider">{
+  &quot;isMigrated&quot;: true
+}</component>
+  <component name="MarkdownSettingsMigration">
+    <option name="stateVersion" value="1" />
+  </component>
+  <component name="ProjectColorInfo">{
+  &quot;associatedIndex&quot;: 2
+}</component>
   <component name="ProjectId" id="2isSqI3Gu08nhEgDFkrUSKJZ4hf" />
+  <component name="ProjectLevelVcsManager">
+    <ConfirmationsSetting value="2" id="Add" />
+  </component>
   <component name="ProjectViewState">
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
@@ -47,9 +78,14 @@
     "RequestMappingsPanelOrder1": "1",
     "RequestMappingsPanelWidth0": "75",
     "RequestMappingsPanelWidth1": "75",
+    "RunOnceActivity.OpenProjectViewOnStart": "true",
     "RunOnceActivity.ShowReadmeOnStart": "true",
+    "SHARE_PROJECT_CONFIGURATION_FILES": "true",
     "Spring Boot.FamilingApplication.executor": "Run",
-    "git-widget-placeholder": "develop",
+    "WebServerToolWindowFactoryState": "false",
+    "com.intellij.testIntegration.createTest.CreateTestDialog.defaultLibrary": "JUnit5",
+    "com.intellij.testIntegration.createTest.CreateTestDialog.defaultLibrarySuperClass.JUnit5": "",
+    "git-widget-placeholder": "feat/3-family",
     "kotlin-language-version-configured": "true",
     "last_opened_file_path": "/Users/sam1616/Desktop/Project/해커톤/familing-backend",
     "node.js.detected.package.eslint": "true",
@@ -63,7 +99,116 @@
     "vue.rearranger.settings.migration": "true"
   }
 }]]></component>
-  <component name="RunManager">
+  <component name="RecentsManager">
+    <key name="CreateTestDialog.Recents.Supers">
+      <recent name="" />
+    </key>
+    <key name="CreateTestDialog.RecentsKey">
+      <recent name="com.pinu.familing.domain.user.service" />
+      <recent name="com.pinu.familing.domain.family.service" />
+      <recent name="com.pinu.familing.domain.family.controller" />
+    </key>
+    <key name="CopyClassDialog.RECENTS_KEY">
+      <recent name="com.pinu.familing.domain.family.repositiry" />
+    </key>
+  </component>
+  <component name="RunManager" selected="Gradle.FamilyServiceTest.addFamilyToUser">
+    <configuration name="FamilyServiceTest" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+      <ExternalSystemSettings>
+        <option name="executionName" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$/familing" />
+        <option name="externalSystemIdString" value="GRADLE" />
+        <option name="scriptParameters" value="" />
+        <option name="taskDescriptions">
+          <list />
+        </option>
+        <option name="taskNames">
+          <list>
+            <option value=":test" />
+            <option value="--tests" />
+            <option value="&quot;com.pinu.familing.domain.family.service.FamilyServiceTest&quot;" />
+          </list>
+        </option>
+        <option name="vmOptions" />
+      </ExternalSystemSettings>
+      <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
+      <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+      <DebugAllEnabled>false</DebugAllEnabled>
+      <RunAsTest>true</RunAsTest>
+      <method v="2" />
+    </configuration>
+    <configuration name="FamilyServiceTest.addFamilyToUser" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+      <ExternalSystemSettings>
+        <option name="executionName" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$/familing" />
+        <option name="externalSystemIdString" value="GRADLE" />
+        <option name="scriptParameters" value="" />
+        <option name="taskDescriptions">
+          <list />
+        </option>
+        <option name="taskNames">
+          <list>
+            <option value=":test" />
+            <option value="--tests" />
+            <option value="&quot;com.pinu.familing.domain.family.service.FamilyServiceTest.addFamilyToUser&quot;" />
+          </list>
+        </option>
+        <option name="vmOptions" />
+      </ExternalSystemSettings>
+      <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
+      <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+      <DebugAllEnabled>false</DebugAllEnabled>
+      <RunAsTest>true</RunAsTest>
+      <method v="2" />
+    </configuration>
+    <configuration name="FamilyServiceTest.createCodeTest" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+      <ExternalSystemSettings>
+        <option name="executionName" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$/familing" />
+        <option name="externalSystemIdString" value="GRADLE" />
+        <option name="scriptParameters" value="" />
+        <option name="taskDescriptions">
+          <list />
+        </option>
+        <option name="taskNames">
+          <list>
+            <option value=":test" />
+            <option value="--tests" />
+            <option value="&quot;com.pinu.familing.domain.family.service.FamilyServiceTest.createCodeTest&quot;" />
+          </list>
+        </option>
+        <option name="vmOptions" />
+      </ExternalSystemSettings>
+      <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
+      <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+      <DebugAllEnabled>false</DebugAllEnabled>
+      <RunAsTest>true</RunAsTest>
+      <method v="2" />
+    </configuration>
+    <configuration name="FamilyServiceTest.createFamilyTest" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+      <ExternalSystemSettings>
+        <option name="executionName" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$/familing" />
+        <option name="externalSystemIdString" value="GRADLE" />
+        <option name="scriptParameters" value="" />
+        <option name="taskDescriptions">
+          <list />
+        </option>
+        <option name="taskNames">
+          <list>
+            <option value=":test" />
+            <option value="--tests" />
+            <option value="&quot;com.pinu.familing.domain.family.service.FamilyServiceTest.createFamilyTest&quot;" />
+          </list>
+        </option>
+        <option name="vmOptions" />
+      </ExternalSystemSettings>
+      <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
+      <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+      <DebugAllEnabled>false</DebugAllEnabled>
+      <RunAsTest>true</RunAsTest>
+      <method v="2" />
+    </configuration>
     <configuration name="FamilingApplication" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot" nameIsGenerated="true">
       <module name="familing.main" />
       <option name="SPRING_BOOT_MAIN_CLASS" value="com.pinu.familing.FamilingApplication" />
@@ -71,6 +216,14 @@
         <option name="Make" enabled="true" />
       </method>
     </configuration>
+    <recent_temporary>
+      <list>
+        <item itemvalue="Gradle.FamilyServiceTest.addFamilyToUser" />
+        <item itemvalue="Gradle.FamilyServiceTest.createFamilyTest" />
+        <item itemvalue="Gradle.FamilyServiceTest.createCodeTest" />
+        <item itemvalue="Gradle.FamilyServiceTest" />
+      </list>
+    </recent_temporary>
   </component>
   <component name="SharedIndexes">
     <attachedChunks>
@@ -89,10 +242,27 @@
       <option name="presentableId" value="Default" />
       <updated>1720277980603</updated>
       <workItem from="1720277981624" duration="1496000" />
+      <workItem from="1721613711222" duration="5087000" />
     </task>
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
     <option name="version" value="3" />
+  </component>
+  <component name="XDebuggerManager">
+    <breakpoint-manager>
+      <breakpoints>
+        <line-breakpoint enabled="true" type="java-line">
+          <url>file://$PROJECT_DIR$/familing/src/main/java/com/pinu/familing/global/oauth/dto/CustomOAuth2User.java</url>
+          <line>28</line>
+          <option name="timeStamp" value="1" />
+        </line-breakpoint>
+        <line-breakpoint enabled="true" type="java-line">
+          <url>file://$PROJECT_DIR$/familing/src/main/java/com/pinu/familing/domain/family/service/FamilyService.java</url>
+          <line>46</line>
+          <option name="timeStamp" value="5" />
+        </line-breakpoint>
+      </breakpoints>
+    </breakpoint-manager>
   </component>
 </project>

--- a/familing/src/main/java/com/pinu/familing/domain/family/controller/FamilyController.java
+++ b/familing/src/main/java/com/pinu/familing/domain/family/controller/FamilyController.java
@@ -1,6 +1,7 @@
 package com.pinu.familing.domain.family.controller;
 
 import com.pinu.familing.domain.family.dto.FamilyCode;
+import com.pinu.familing.domain.family.dto.FamilyName;
 import com.pinu.familing.domain.family.service.FamilyService;
 import com.pinu.familing.domain.user.service.UserService;
 import com.pinu.familing.global.oauth.dto.CustomOAuth2User;
@@ -14,25 +15,9 @@ import org.springframework.web.bind.annotation.RestController;
 public class FamilyController {
 
     private final FamilyService familyService;
-    private final UserService userService;
-    public FamilyController(FamilyService familyService, UserService userService) {
+    public FamilyController(FamilyService familyService) {
         this.familyService = familyService;
-        this.userService = userService;
     }
-
-    /*
-     * >  뭔가 제 생각! 가족 유무를 체크 하고 없으면 이 단계를 거치게끔 하고 싶은데요!..!!
-     * >  준형님이 일단 구현을 해보라고 햇으니까 해볼게용
-     *
-     * 흐름
-     * 근데 이 부분 프론트에서 요청을 보낼 것 같네요
-     *  - 유저가 패밀리에 등록되어있는 경우
-     *  - 유저가 패밀리가 없는 경우
-     *
-     * 이 검증도 하나의 메서드에서 할까요?
-     *
-     * 아니면 이건 따로 검증
-     */
 
     /**
      * <가족 생성 로직>
@@ -42,9 +27,9 @@ public class FamilyController {
      *
      */
     @PostMapping("/family")
-    public ResponseEntity<?> registerFamily(@AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
-        String code = familyService.createFamily(customOAuth2User.getName());
-        userService.addFamilyToUser(customOAuth2User.getName(),code);
+    public ResponseEntity<?> createFamily(@AuthenticationPrincipal CustomOAuth2User customOAuth2User, FamilyName familyName) {
+        String code = familyService.registerNewFamily(customOAuth2User.getName(), familyName.name());
+        familyService.addFamilyToUser(customOAuth2User.getName(),code);
         return ResponseEntity.ok("가족 생성과 추가 성공");
     }
 
@@ -56,8 +41,7 @@ public class FamilyController {
      */
     @PutMapping("/family")
     public ResponseEntity<?> registerFamily(@AuthenticationPrincipal CustomOAuth2User customOAuth2User, FamilyCode familyCode) {
-        String validCode = familyService.validFamilyCode(familyCode.code());
-        userService.addFamilyToUser(customOAuth2User.getName(),validCode);
+        familyService.addFamilyToUser(customOAuth2User.getName(),familyCode.code());
         return ResponseEntity.ok("successfully registered family");
     }
 

--- a/familing/src/main/java/com/pinu/familing/domain/family/controller/FamilyController.java
+++ b/familing/src/main/java/com/pinu/familing/domain/family/controller/FamilyController.java
@@ -1,0 +1,66 @@
+package com.pinu.familing.domain.family.controller;
+
+import com.pinu.familing.domain.family.dto.FamilyCode;
+import com.pinu.familing.domain.family.service.FamilyService;
+import com.pinu.familing.domain.user.service.UserService;
+import com.pinu.familing.global.oauth.dto.CustomOAuth2User;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class FamilyController {
+
+    private final FamilyService familyService;
+    private final UserService userService;
+    public FamilyController(FamilyService familyService, UserService userService) {
+        this.familyService = familyService;
+        this.userService = userService;
+    }
+
+    /*
+     * >  뭔가 제 생각! 가족 유무를 체크 하고 없으면 이 단계를 거치게끔 하고 싶은데요!..!!
+     * >  준형님이 일단 구현을 해보라고 햇으니까 해볼게용
+     *
+     * 흐름
+     * 근데 이 부분 프론트에서 요청을 보낼 것 같네요
+     *  - 유저가 패밀리에 등록되어있는 경우
+     *  - 유저가 패밀리가 없는 경우
+     *
+     * 이 검증도 하나의 메서드에서 할까요?
+     *
+     * 아니면 이건 따로 검증
+     */
+
+    /**
+     * <가족 생성 로직>
+     * 유저가 가족을 가지고 있는지 검사
+     * 유저 정보 기반으로 코드 발급 + 가족 생성
+     * 유저에 가족 정보 넣기(이거 유저 서비스로 옮길까 심히 고민 중)
+     *
+     */
+    @PostMapping("/family")
+    public ResponseEntity<?> registerFamily(@AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        String code = familyService.createFamily(customOAuth2User.getName());
+        userService.addFamilyToUser(customOAuth2User.getName(),code);
+        return ResponseEntity.ok("가족 생성과 추가 성공");
+    }
+
+    /**
+     * <가족 등록 로직>
+     * 유저가 가족을 가지고 있는지 검사 (누가 로직을 가지고 있는게 좋을까요?
+     * 유효한 가족 코드 확인
+     * 유저 정보 넣기
+     */
+    @PutMapping("/family")
+    public ResponseEntity<?> registerFamily(@AuthenticationPrincipal CustomOAuth2User customOAuth2User, FamilyCode familyCode) {
+        String validCode = familyService.validFamilyCode(familyCode.code());
+        userService.addFamilyToUser(customOAuth2User.getName(),validCode);
+        return ResponseEntity.ok("successfully registered family");
+    }
+
+
+
+}

--- a/familing/src/main/java/com/pinu/familing/domain/family/dto/FamilyCode.java
+++ b/familing/src/main/java/com/pinu/familing/domain/family/dto/FamilyCode.java
@@ -1,0 +1,6 @@
+package com.pinu.familing.domain.family.dto;
+
+public record FamilyCode(
+        String code){
+
+}

--- a/familing/src/main/java/com/pinu/familing/domain/family/dto/FamilyName.java
+++ b/familing/src/main/java/com/pinu/familing/domain/family/dto/FamilyName.java
@@ -1,2 +1,4 @@
-package com.pinu.familing.domain.family.dto;public record FamilyName() {
+package com.pinu.familing.domain.family.dto;
+
+public record FamilyName(String name) {
 }

--- a/familing/src/main/java/com/pinu/familing/domain/family/dto/FamilyName.java
+++ b/familing/src/main/java/com/pinu/familing/domain/family/dto/FamilyName.java
@@ -1,0 +1,2 @@
+package com.pinu.familing.domain.family.dto;public record FamilyName() {
+}

--- a/familing/src/main/java/com/pinu/familing/domain/family/entity/Family.java
+++ b/familing/src/main/java/com/pinu/familing/domain/family/entity/Family.java
@@ -21,7 +21,8 @@ public class Family {
     @Column(nullable = false, unique = true)
     private String code;
 
-    public Family(String code) {
+    public Family(String familyName, String code) {
+        this.familyName = familyName;
         this.code = code;
     }
 }

--- a/familing/src/main/java/com/pinu/familing/domain/family/entity/Family.java
+++ b/familing/src/main/java/com/pinu/familing/domain/family/entity/Family.java
@@ -1,0 +1,27 @@
+package com.pinu.familing.domain.family.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/*
+ * 가족 그룹 생성을 언제 할까요?!
+ */
+@Entity
+@Getter
+@NoArgsConstructor
+public class Family {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String familyName;
+
+    @Column(nullable = false, unique = true)
+    private String code;
+
+    public Family(String code) {
+        this.code = code;
+    }
+}

--- a/familing/src/main/java/com/pinu/familing/domain/family/handler/FamilyCodeHandler.java
+++ b/familing/src/main/java/com/pinu/familing/domain/family/handler/FamilyCodeHandler.java
@@ -1,2 +1,33 @@
-package com.pinu.familing.domain.family.handler;public class FamilyCodeHandler {
+package com.pinu.familing.domain.family.handler;
+
+import com.pinu.familing.global.error.CustomException;
+import com.pinu.familing.global.error.ExceptionCode;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+public class FamilyCodeHandler {
+
+    private static final char[] BASE_62_CHARS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz".toCharArray();
+
+    public static String createCode(String name) {
+        StringBuilder sb = new StringBuilder();
+
+        // SHA-256 해시 함수를 사용하여 입력값을 해시
+        MessageDigest md;
+        try {
+            md = MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new CustomException(ExceptionCode.FAILED_CODE_GENERATION);
+        }
+        byte[] hash = md.digest(name.getBytes());
+
+        // 해시 값을 Base62로 인코딩
+        for (byte b : hash) {
+            sb.append(BASE_62_CHARS[((b & 0xFF) % BASE_62_CHARS.length)]);
+        }
+
+        //길이 12으로 제한
+        return sb.substring(0, 12);
+    }
 }

--- a/familing/src/main/java/com/pinu/familing/domain/family/handler/FamilyCodeHandler.java
+++ b/familing/src/main/java/com/pinu/familing/domain/family/handler/FamilyCodeHandler.java
@@ -1,0 +1,2 @@
+package com.pinu.familing.domain.family.handler;public class FamilyCodeHandler {
+}

--- a/familing/src/main/java/com/pinu/familing/domain/family/repositiry/FamilyRepository.java
+++ b/familing/src/main/java/com/pinu/familing/domain/family/repositiry/FamilyRepository.java
@@ -1,0 +1,13 @@
+package com.pinu.familing.domain.family.repositiry;
+
+import com.pinu.familing.domain.family.entity.Family;
+import com.pinu.familing.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface FamilyRepository extends JpaRepository<Family, Long> {
+    boolean existsByCode(String code);
+
+    Optional<Family> findByCode(String code);
+}

--- a/familing/src/main/java/com/pinu/familing/domain/family/service/FamilyService.java
+++ b/familing/src/main/java/com/pinu/familing/domain/family/service/FamilyService.java
@@ -1,0 +1,65 @@
+package com.pinu.familing.domain.family.service;
+
+import com.pinu.familing.domain.family.entity.Family;
+import com.pinu.familing.domain.family.repositiry.FamilyRepository;
+import com.pinu.familing.domain.user.entity.User;
+import com.pinu.familing.domain.user.repository.UserRepository;
+import com.pinu.familing.global.error.CustomException;
+import com.pinu.familing.global.error.ExceptionCode;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+@Service
+public class FamilyService {
+
+    private static final char[] BASE_62_CHARS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz".toCharArray();
+    private final UserRepository userRepository;
+    private final FamilyRepository familyRepository;
+
+    public FamilyService(UserRepository userRepository, FamilyRepository familyRepository) {
+        this.userRepository = userRepository;
+        this.familyRepository = familyRepository;
+    }
+
+    //가족 만들기
+    @Transactional
+    public String createFamily(String userName){
+        String code = createCode(userName);
+        String validCode = validFamilyCode(code);
+        //준형님 제가 요즘 도메인에 로직을 담는게 좋다는 이야기를 들었어요. 저도 그렇게 생각하는데.. 흠
+        Family savefamily = familyRepository.save(new Family(validCode));
+        return savefamily.getCode();
+    }
+
+
+    public String validFamilyCode(String code) {
+        if (familyRepository.existsByCode(code)) {
+            throw new CustomException(ExceptionCode.INVALID_CODE);
+        }
+        return code;
+    }
+
+
+    private String createCode(String name) {
+        StringBuilder sb = new StringBuilder();
+
+        // SHA-256 해시 함수를 사용하여 입력값을 해시
+        MessageDigest md;
+        try {
+            md = MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new CustomException(ExceptionCode.FAILED_CODE_GENERATION);
+        }
+        byte[] hash = md.digest(name.getBytes());
+
+        // 해시 값을 Base62로 인코딩
+        for (byte b : hash) {
+            sb.append(BASE_62_CHARS[((b & 0xFF) % BASE_62_CHARS.length)]);
+        }
+        return sb.toString();
+    }
+
+}

--- a/familing/src/main/java/com/pinu/familing/domain/family/service/FamilyService.java
+++ b/familing/src/main/java/com/pinu/familing/domain/family/service/FamilyService.java
@@ -1,11 +1,14 @@
 package com.pinu.familing.domain.family.service;
 
+import com.pinu.familing.domain.family.dto.FamilyCode;
 import com.pinu.familing.domain.family.entity.Family;
+import com.pinu.familing.domain.family.handler.FamilyCodeHandler;
 import com.pinu.familing.domain.family.repositiry.FamilyRepository;
 import com.pinu.familing.domain.user.entity.User;
 import com.pinu.familing.domain.user.repository.UserRepository;
 import com.pinu.familing.global.error.CustomException;
 import com.pinu.familing.global.error.ExceptionCode;
+import org.aspectj.apache.bcel.classfile.Code;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,7 +18,6 @@ import java.security.NoSuchAlgorithmException;
 @Service
 public class FamilyService {
 
-    private static final char[] BASE_62_CHARS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz".toCharArray();
     private final UserRepository userRepository;
     private final FamilyRepository familyRepository;
 
@@ -26,40 +28,31 @@ public class FamilyService {
 
     //가족 만들기
     @Transactional
-    public String createFamily(String userName){
-        String code = createCode(userName);
-        String validCode = validFamilyCode(code);
-        //준형님 제가 요즘 도메인에 로직을 담는게 좋다는 이야기를 들었어요. 저도 그렇게 생각하는데.. 흠
-        Family savefamily = familyRepository.save(new Family(validCode));
+    public String registerNewFamily(String userName,String familyName){
+        String validCode = validFamilyCode(FamilyCodeHandler.createCode(userName));
+
+        Family family = new Family(familyName,validCode);
+        Family savefamily = familyRepository.save(family);
+
         return savefamily.getCode();
     }
 
+    @Transactional
+    public void addFamilyToUser(String userName, String code) {
+        User user = userRepository.findByUsername(userName);
 
-    public String validFamilyCode(String code) {
+        Family family = familyRepository.findByCode(code)
+                .orElseThrow(()-> new CustomException(ExceptionCode.INVALID_CODE));
+
+        //내부에 예외 처리 부분 넣어놨습니다.
+        user.registerFamily(family);
+    }
+
+    private String validFamilyCode(String code) {
         if (familyRepository.existsByCode(code)) {
             throw new CustomException(ExceptionCode.INVALID_CODE);
         }
         return code;
-    }
-
-
-    private String createCode(String name) {
-        StringBuilder sb = new StringBuilder();
-
-        // SHA-256 해시 함수를 사용하여 입력값을 해시
-        MessageDigest md;
-        try {
-            md = MessageDigest.getInstance("SHA-256");
-        } catch (NoSuchAlgorithmException e) {
-            throw new CustomException(ExceptionCode.FAILED_CODE_GENERATION);
-        }
-        byte[] hash = md.digest(name.getBytes());
-
-        // 해시 값을 Base62로 인코딩
-        for (byte b : hash) {
-            sb.append(BASE_62_CHARS[((b & 0xFF) % BASE_62_CHARS.length)]);
-        }
-        return sb.toString();
     }
 
 }

--- a/familing/src/main/java/com/pinu/familing/domain/user/dto/UserDto.java
+++ b/familing/src/main/java/com/pinu/familing/domain/user/dto/UserDto.java
@@ -1,5 +1,7 @@
 package com.pinu.familing.domain.user.dto;
 
 
-public record UserDto(String username, String nickname, String role) {
+public record UserDto(String username,
+                      String nickname,
+                      String role) {
 }

--- a/familing/src/main/java/com/pinu/familing/domain/user/entity/User.java
+++ b/familing/src/main/java/com/pinu/familing/domain/user/entity/User.java
@@ -1,7 +1,10 @@
 package com.pinu.familing.domain.user.entity;
 
 import com.pinu.familing.domain.BaseEntity;
+import com.pinu.familing.domain.family.entity.Family;
 import com.pinu.familing.domain.user.Gender;
+import com.pinu.familing.global.error.CustomException;
+import com.pinu.familing.global.error.ExceptionCode;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,7 +14,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @Table(name = "user_tb")
-public class User extends BaseEntity{
+public class User extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -24,7 +27,23 @@ public class User extends BaseEntity{
     @Enumerated(value = EnumType.STRING)
     private Gender gender;
 
+    @ManyToOne
+    @JoinColumn(name = "family_id")
+    private Family family;
+
     private int age;
+
+    private String role;
+
+    @Builder
+    private User(String username, String nickname, String role, int age, Gender gender, Family family) {
+        this.username = username;
+        this.nickname = nickname;
+        this.role = role;
+        this.age = age;
+        this.gender = gender;
+        this.family = family;
+    }
 
     @Builder
     private User(String username, String nickname, String role, int age, Gender gender) {
@@ -35,6 +54,17 @@ public class User extends BaseEntity{
         this.gender = gender;
     }
 
-    private String role;
+    public void registerFamily(Family family) {
+        if (this.family != null) {
+            throw new CustomException(ExceptionCode.ALREADY_HAVE_FAMILY);
+        }
+        this.family = family;
+    }
 
+    public boolean existsFamily() {
+        if (this.family != null) {
+            return true;
+        }
+        return true;
+    }
 }

--- a/familing/src/main/java/com/pinu/familing/domain/user/entity/User.java
+++ b/familing/src/main/java/com/pinu/familing/domain/user/entity/User.java
@@ -60,11 +60,4 @@ public class User extends BaseEntity {
         }
         this.family = family;
     }
-
-    public boolean existsFamily() {
-        if (this.family != null) {
-            return true;
-        }
-        return true;
-    }
 }

--- a/familing/src/main/java/com/pinu/familing/domain/user/service/UserService.java
+++ b/familing/src/main/java/com/pinu/familing/domain/user/service/UserService.java
@@ -1,0 +1,34 @@
+package com.pinu.familing.domain.user.service;
+
+import com.pinu.familing.domain.family.entity.Family;
+import com.pinu.familing.domain.family.repositiry.FamilyRepository;
+import com.pinu.familing.domain.user.entity.User;
+import com.pinu.familing.domain.user.repository.UserRepository;
+import com.pinu.familing.global.error.CustomException;
+import com.pinu.familing.global.error.ExceptionCode;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final FamilyRepository familyRepository;
+
+    public UserService(UserRepository userRepository, FamilyRepository familyRepository) {
+        this.userRepository = userRepository;
+        this.familyRepository = familyRepository;
+    }
+
+
+    @Transactional
+    public void addFamilyToUser(String userName, String code) {
+        User user = userRepository.findByUsername(userName);
+        //코드가 존재하지 않는 경우 (사용자가 잘못된 코드)
+        Family family = familyRepository.findByCode(code)
+                .orElseThrow(()-> new CustomException(ExceptionCode.INVALID_CODE));
+
+        //내부에 예외 처리 부분 넣어놨습니다.
+        user.registerFamily(family);
+    }
+}

--- a/familing/src/main/java/com/pinu/familing/domain/user/service/UserService.java
+++ b/familing/src/main/java/com/pinu/familing/domain/user/service/UserService.java
@@ -1,13 +1,8 @@
 package com.pinu.familing.domain.user.service;
 
-import com.pinu.familing.domain.family.entity.Family;
 import com.pinu.familing.domain.family.repositiry.FamilyRepository;
-import com.pinu.familing.domain.user.entity.User;
 import com.pinu.familing.domain.user.repository.UserRepository;
-import com.pinu.familing.global.error.CustomException;
-import com.pinu.familing.global.error.ExceptionCode;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class UserService {
@@ -20,15 +15,4 @@ public class UserService {
         this.familyRepository = familyRepository;
     }
 
-
-    @Transactional
-    public void addFamilyToUser(String userName, String code) {
-        User user = userRepository.findByUsername(userName);
-        //코드가 존재하지 않는 경우 (사용자가 잘못된 코드)
-        Family family = familyRepository.findByCode(code)
-                .orElseThrow(()-> new CustomException(ExceptionCode.INVALID_CODE));
-
-        //내부에 예외 처리 부분 넣어놨습니다.
-        user.registerFamily(family);
-    }
 }

--- a/familing/src/main/java/com/pinu/familing/global/error/ExceptionCode.java
+++ b/familing/src/main/java/com/pinu/familing/global/error/ExceptionCode.java
@@ -12,8 +12,13 @@ public enum ExceptionCode {
     USER_FORBIDDEN(HttpStatus.FORBIDDEN, "권한이 없습니다."),
 
     // 잘못된 접근
-    BAD_APPROACH(HttpStatus.BAD_REQUEST, "잘못된 접근입니다.");
+    BAD_APPROACH(HttpStatus.BAD_REQUEST, "잘못된 접근입니다."),
 
+    //가족 코드 생성중
+    FAILED_CODE_GENERATION(HttpStatus.BAD_REQUEST, "잘못된 접근입니다."),
+    ALREADY_HAVE_FAMILY(HttpStatus.BAD_REQUEST, "가족이 있습니다"),
+    INVALID_CODE(HttpStatus.BAD_REQUEST,"코드가 유효하지않습니다.")
+    ;
 
 
     private final HttpStatus httpStatus;

--- a/familing/src/test/java/com/pinu/familing/domain/user/service/UserServiceTest.java
+++ b/familing/src/test/java/com/pinu/familing/domain/user/service/UserServiceTest.java
@@ -1,0 +1,10 @@
+package com.pinu.familing.domain.user.service;
+
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class UserServiceTest {
+
+}


### PR DESCRIPTION
## #3 

> 가족 생성 등록햇습니당

### #3 
가족 생성과 가족 등록
- [ x] 기능 추가

### 반영 브랜치
ex) feat/3-login -> dev

### 변경 사항 설명

가족 그룹 생성 로직(코드발급)
```
FamilyController: createFamily
 ㄴ 유저네임과 원하는 가족 이름을 전달받아
     ㄴ 코드 생성은 (FamilyCodeHandler
     ㄴ 유효성 검사는 FamilyService가 
     ㄴ 가족 생성과  엔티티 저장
 ㄴ  가족 그룹 참가
      ㄴ  유저 찾기
      ㄴ 코드로 가족 찾기
      ㄴ 유저에 패밀리 저장
```
코드로 가족 그룹 참가 로직
```
FamilyController: registerFamily
 ㄴ  가족 그룹 참가
```

### 테스트 결과
- 가족 등록, 가족 그룹 참가 로직 정상
- 이미 가족이 있는 유저 가족 그룹 참가시 정상 에러반환
- 잘못된 코드로 요청하는 경우 정상 에러 반환

### 💬리뷰 요구사항(선택)
1. 핸들러 놨는데 좀 과한가요? 

2. 우리 가족 이름 결성이 생각해보니까 이 지점이 아닌 거 ㅅ같기도 스타일 가이드 볼게요
