### PR TITLE
Feat/48 kakao 엑세스 토큰전달받아서 로그인 

### DIFF
--- a/familing/src/main/java/com/pinu/familing/FamilingApplication.java
+++ b/familing/src/main/java/com/pinu/familing/FamilingApplication.java
@@ -2,12 +2,14 @@ package com.pinu.familing;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableScheduling
+@ConfigurationPropertiesScan
 public class FamilingApplication {
 
     public static void main(String[] args) {

--- a/familing/src/main/java/com/pinu/familing/domain/family/controller/FamilyController.java
+++ b/familing/src/main/java/com/pinu/familing/domain/family/controller/FamilyController.java
@@ -6,6 +6,7 @@ import com.pinu.familing.domain.family.dto.FamilyName;
 import com.pinu.familing.domain.family.service.FamilyService;
 import com.pinu.familing.domain.user.service.UserService;
 import com.pinu.familing.global.oauth.dto.CustomOAuth2User;
+import com.pinu.familing.global.oauth.dto.PrincipalDetails;
 import com.pinu.familing.global.util.ApiUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -29,12 +30,12 @@ public class FamilyController {
      * 가족 코드
      */
     @PostMapping("/family")
-    public ApiUtils.ApiResult<?> createFamily(@AuthenticationPrincipal CustomOAuth2User customOAuth2User, @RequestBody FamilyName familyName) {
+    public ApiUtils.ApiResult<?> createFamily(@AuthenticationPrincipal PrincipalDetails principalDetails, @RequestBody FamilyName familyName) {
         Map<String, Object> responseBody = new HashMap<>();
         //가족 코드 생성 로직
-        FamilyDto familyDto = familyService.registerNewFamily(customOAuth2User.getName(), familyName.name());
+        FamilyDto familyDto = familyService.registerNewFamily(principalDetails.getUsername(), familyName.name());
         //유저에 가족을 넣기
-        userService.addFamilyToUser(customOAuth2User, familyDto.code());
+        userService.addFamilyToUser(principalDetails.getUsername(), familyDto.code());
         responseBody.put("code", familyDto.code());
         return ApiUtils.success(responseBody);
     }
@@ -46,15 +47,15 @@ public class FamilyController {
      * 유저 정보 넣기
      */
     @PostMapping("/family/user")
-    public ApiUtils.ApiResult<String> registerFamily(@AuthenticationPrincipal CustomOAuth2User customOAuth2User, @RequestBody FamilyCode familyCode) {
+    public ApiUtils.ApiResult<String> registerFamily(@AuthenticationPrincipal PrincipalDetails principalDetails, @RequestBody FamilyCode familyCode) {
         //유저에 가족을 넣기
-        userService.addFamilyToUser(customOAuth2User, familyCode.code());
+        userService.addFamilyToUser(principalDetails.getUsername(), familyCode.code());
         return ApiUtils.success("Successful addition of family");
     }
 
     @GetMapping("/family")
-    public ApiUtils.ApiResult<?> getMyFamily(@AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
-        return ApiUtils.success(familyService.getMyFamily(customOAuth2User.getName()));
+    public ApiUtils.ApiResult<?> getMyFamily(@AuthenticationPrincipal PrincipalDetails principalDetails) {
+        return ApiUtils.success(familyService.getMyFamily(principalDetails.getUsername()));
     }
 
 }

--- a/familing/src/main/java/com/pinu/familing/domain/lovecard/controller/LovecardController.java
+++ b/familing/src/main/java/com/pinu/familing/domain/lovecard/controller/LovecardController.java
@@ -4,6 +4,7 @@ import com.pinu.familing.domain.lovecard.service.LovecardService;
 import com.pinu.familing.domain.snapshot.dto.CustomPage;
 import com.pinu.familing.domain.lovecard.dto.LovecardRequest;
 import com.pinu.familing.global.oauth.dto.CustomOAuth2User;
+import com.pinu.familing.global.oauth.dto.PrincipalDetails;
 import com.pinu.familing.global.util.ApiUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -25,18 +26,18 @@ public class LovecardController{
 
     //가족구성원별 주고받은 애정 카드 조회
     @GetMapping("/familys/{family_username}")
-    public ApiUtils.ApiResult<?> getLoveCardLogList(@AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+    public ApiUtils.ApiResult<?> getLoveCardLogList(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                     @PathVariable("family_username") String familyUsername,
                                                     Pageable pageable) {
-        return ApiUtils.success(new CustomPage(lovecardService.getLovecardByFamilyLogPage(customOAuth2User.getName(), familyUsername,pageable)));
+        return ApiUtils.success(new CustomPage(lovecardService.getLovecardByFamilyLogPage(principalDetails.getUsername(), familyUsername,pageable)));
     }
 
     //원하는 가족에게 카드보내기
     @PostMapping("/familys/{familys_username}")
-    public ApiUtils.ApiResult<?> getLoveCardLogList(@AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+    public ApiUtils.ApiResult<?> getLoveCardLogList(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                     @PathVariable("family_username") String familyUsername,
                                                     @RequestBody LovecardRequest lovecardRequest) {
-        lovecardService.sendLoveCardToFamily(customOAuth2User.getName(), familyUsername, lovecardRequest);
+        lovecardService.sendLoveCardToFamily(principalDetails.getUsername(), familyUsername, lovecardRequest);
         return ApiUtils.success("Lovecard has been sent successfully.");
     }
 

--- a/familing/src/main/java/com/pinu/familing/domain/snapshot/controller/SnapshotController.java
+++ b/familing/src/main/java/com/pinu/familing/domain/snapshot/controller/SnapshotController.java
@@ -7,6 +7,7 @@ import com.pinu.familing.domain.snapshot.service.SnapshotService;
 import com.pinu.familing.global.error.CustomException;
 import com.pinu.familing.global.error.ExceptionCode;
 import com.pinu.familing.global.oauth.dto.CustomOAuth2User;
+import com.pinu.familing.global.oauth.dto.PrincipalDetails;
 import com.pinu.familing.global.util.ApiUtils;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -36,47 +37,47 @@ public class SnapshotController {
     // 특정 날짜 스냅샷 조회
     @GetMapping("/{day}")
     public ApiUtils.ApiResult<?> getSnapshotByDate(@PathVariable("day") LocalDate day,
-                                                 @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
-        SnapshotResponse snapshot = snapshotService.getSnapshotByDate(day, customOAuth2User.getName());
+                                                 @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        SnapshotResponse snapshot = snapshotService.getSnapshotByDate(day, principalDetails.getUsername());
         return ApiUtils.success(snapshot);
     }
 
     //스냅샷 페이지 조회
     @GetMapping(value = "/{day}", params = "page")
     public ApiUtils.ApiResult<?> getSnapshotPage(@PathVariable("day") LocalDate day, Pageable pageable,
-                                                @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
-        Page<SnapshotResponse> snapshotPage = snapshotService.getSnapshotPage(day, pageable, customOAuth2User.getName());
+                                                @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        Page<SnapshotResponse> snapshotPage = snapshotService.getSnapshotPage(day, pageable, principalDetails.getUsername());
         return ApiUtils.success(new CustomPage(snapshotPage));
     }
 
     //스냅샷 이미지 등록
     @PostMapping("/{day}/users")
     public ApiUtils.ApiResult<?> registerSnapshotImage(@PathVariable("day") LocalDate day,
-                                                       @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+                                                       @AuthenticationPrincipal PrincipalDetails principalDetails,
                                                        @RequestPart("snapshot_img") MultipartFile snapshotImage) {
         if (snapshotImage.isEmpty()) {
             throw new CustomException(REQUIRE_IMG);
         }
-        snapshotService.registerSnapshotImage(day, customOAuth2User.getName(), snapshotImage);
+        snapshotService.registerSnapshotImage(day, principalDetails.getUsername(), snapshotImage);
         return ApiUtils.success("Image has been registered successfully.");
     }
 
 
     // 스냅샷 알람 변경 요청 저장하기
     @PostMapping("/alarm")
-    public ApiUtils.ApiResult<?> setSnapshotAlarmTime(@AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+    public ApiUtils.ApiResult<?> setSnapshotAlarmTime(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                       @RequestParam(name = "time") String time) {
         LocalTime targetTime = LocalTime.parse(time);
-        snapshotService.changeAlarmTime(customOAuth2User.getName(), targetTime);
+        snapshotService.changeAlarmTime(principalDetails.getUsername(), targetTime);
         return ApiUtils.success("Snapshot alarm has been converted successfully.");
     }
 
 
     // 스냅샷 알람 조회
     @GetMapping("/alarm")
-    public ApiUtils.ApiResult<?> getSnapshotAlarmTime(@AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+    public ApiUtils.ApiResult<?> getSnapshotAlarmTime(@AuthenticationPrincipal PrincipalDetails principalDetails) {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm");
-        return ApiUtils.success(snapshotService.getSnapshotAlarmTime(customOAuth2User.getName()).format(formatter));
+        return ApiUtils.success(snapshotService.getSnapshotAlarmTime(principalDetails.getUsername()).format(formatter));
     }
 
 

--- a/familing/src/main/java/com/pinu/familing/domain/status/controller/StatusController.java
+++ b/familing/src/main/java/com/pinu/familing/domain/status/controller/StatusController.java
@@ -3,6 +3,7 @@ package com.pinu.familing.domain.status.controller;
 import com.pinu.familing.domain.status.dto.StatusRequest;
 import com.pinu.familing.domain.status.service.StatusService;
 import com.pinu.familing.global.oauth.dto.CustomOAuth2User;
+import com.pinu.familing.global.oauth.dto.PrincipalDetails;
 import com.pinu.familing.global.util.ApiUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -26,17 +27,17 @@ public class StatusController {
 
     //유저의 상태 변경
     @PatchMapping("/users")
-    public ApiUtils.ApiResult<?> changeUserStatus(@AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+    public ApiUtils.ApiResult<?> changeUserStatus(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                   StatusRequest statusRequest) {
-        statusService.changeUserStatus(customOAuth2User.getName(), statusRequest);
+        statusService.changeUserStatus(principalDetails.getUsername(), statusRequest);
         return ApiUtils.success("User's status has been successfully changed.");
     }
 
 
     //유저와 가족의 상태 조회
     @GetMapping("/family")
-    public ApiUtils.ApiResult<?> changeFamilyStatus(@AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
-        statusService.getFamilyStatusList(customOAuth2User.getName());
+    public ApiUtils.ApiResult<?> changeFamilyStatus(@AuthenticationPrincipal PrincipalDetails principalDetails) {
+        statusService.getFamilyStatusList(principalDetails.getUsername());
         return ApiUtils.success("User's status has been successfully changed.");
     }
 }

--- a/familing/src/main/java/com/pinu/familing/domain/user/controller/UserController.java
+++ b/familing/src/main/java/com/pinu/familing/domain/user/controller/UserController.java
@@ -6,6 +6,7 @@ import com.pinu.familing.domain.user.dto.UserResponse;
 import com.pinu.familing.domain.user.service.UserService;
 import com.pinu.familing.global.oauth.dto.CustomOAuth2User;
 import com.pinu.familing.global.s3.S3ImgDto;
+import com.pinu.familing.global.oauth.dto.PrincipalDetails;
 import com.pinu.familing.global.util.ApiUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -20,8 +21,8 @@ public class UserController {
     private final UserService userService;
 
     @GetMapping("/user")
-    public ApiUtils.ApiResult<UserResponse> giveUserInformation(@AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
-        return ApiUtils.success(userService.giveUserInformation(customOAuth2User));
+    public ApiUtils.ApiResult<UserResponse> giveUserInformation(@AuthenticationPrincipal PrincipalDetails principalDetails) {
+        return ApiUtils.success(userService.giveUserInformation(principalDetails.getUsername()));
     }
 
     //닉네임 변경

--- a/familing/src/main/java/com/pinu/familing/domain/user/controller/UserController.java
+++ b/familing/src/main/java/com/pinu/familing/domain/user/controller/UserController.java
@@ -27,23 +27,23 @@ public class UserController {
 
     //닉네임 변경
     @PatchMapping("/user/nickname")
-    public ApiUtils.ApiResult<?> changeNickname(@AuthenticationPrincipal CustomOAuth2User customOAuth2User, @RequestBody Nickname nickname) {
-        userService.changeNickname(customOAuth2User, nickname);
+    public ApiUtils.ApiResult<?> changeNickname(@AuthenticationPrincipal PrincipalDetails principalDetails, @RequestBody Nickname nickname) {
+        userService.changeNickname(principalDetails.getUsername(), nickname);
         return ApiUtils.success("Successful nickname changed");
     }
 
     //진짜 이름 변경
     @PatchMapping("/user/realname")
-    public ApiUtils.ApiResult<?> changeRealname(@AuthenticationPrincipal CustomOAuth2User customOAuth2User, @RequestBody Realname realname) {
-        userService.changeRealname(customOAuth2User, realname);
+    public ApiUtils.ApiResult<?> changeRealname(@AuthenticationPrincipal PrincipalDetails principalDetails, @RequestBody Realname realname) {
+        userService.changeRealname(principalDetails.getUsername(), realname);
         return ApiUtils.success("Successful realname changed");
     }
 
 
     //프로필 이미지 변경
     @PatchMapping("/user/profile")
-    public ApiUtils.ApiResult<?> changeImageUrl(@AuthenticationPrincipal CustomOAuth2User customOAuth2User, @RequestPart MultipartFile profileImg) {
-        S3ImgDto s3ImgDto = userService.changeProfileImg(customOAuth2User, profileImg);
+    public ApiUtils.ApiResult<?> changeImageUrl(@AuthenticationPrincipal PrincipalDetails principalDetails, @RequestPart MultipartFile profileImg) {
+        S3ImgDto s3ImgDto = userService.changeProfileImg(principalDetails.getUsername(), profileImg);
         return ApiUtils.success(s3ImgDto);
     }
 }

--- a/familing/src/main/java/com/pinu/familing/domain/user/service/UserService.java
+++ b/familing/src/main/java/com/pinu/familing/domain/user/service/UserService.java
@@ -33,8 +33,8 @@ public class UserService {
     private final StatusRepository statusRepository;
 
 
-    public UserResponse giveUserInformation(CustomOAuth2User customOAuth2User) {
-        User user = userRepository.findByUsername(customOAuth2User.getName())
+    public UserResponse giveUserInformation(String username) {
+        User user = userRepository.findByUsername(username)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
         return UserResponse.fromEntity(user);
     }

--- a/familing/src/main/java/com/pinu/familing/domain/user/service/UserService.java
+++ b/familing/src/main/java/com/pinu/familing/domain/user/service/UserService.java
@@ -41,9 +41,9 @@ public class UserService {
 
 
     @Transactional
-    public void addFamilyToUser(CustomOAuth2User customOAuth2User, String code) {
+    public void addFamilyToUser(String username, String code) {
         //유저 찾기
-        User user = userRepository.findByUsername(customOAuth2User.getName())
+        User user = userRepository.findByUsername(username)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
         Family family = familyRepository.findByCode(code)
@@ -60,22 +60,22 @@ public class UserService {
     }
 
     @Transactional
-    public void changeNickname(CustomOAuth2User customOAuth2User, Nickname nickname) {
-        User user = userRepository.findByUsername(customOAuth2User.getName())
+    public void changeNickname(String username, Nickname nickname) {
+        User user = userRepository.findByUsername(username)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
         user.updateNickname(nickname);
     }
 
     @Transactional
-    public void changeRealname(CustomOAuth2User customOAuth2User, Realname realname) {
-        User user = userRepository.findByUsername(customOAuth2User.getName())
+    public void changeRealname(String username, Realname realname) {
+        User user = userRepository.findByUsername(username)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
         user.updateRealname(realname);
     }
 
     @Transactional
-    public S3ImgDto changeProfileImg(CustomOAuth2User customOAuth2User, MultipartFile profileImg) {
-        User user = userRepository.findByUsername(customOAuth2User.getName())
+    public S3ImgDto changeProfileImg(String username, MultipartFile profileImg) {
+        User user = userRepository.findByUsername(username)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
         String beforeProfile = user.getProfileImg();

--- a/familing/src/main/java/com/pinu/familing/global/config/SecurityConfig.java
+++ b/familing/src/main/java/com/pinu/familing/global/config/SecurityConfig.java
@@ -8,11 +8,16 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.context.SecurityContextPersistenceFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 
@@ -23,8 +28,8 @@ import java.util.Collections;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-    private final CustomOAuth2UserService customOAuth2UserService;
-    private final CustomSuccessHandler customSuccessHandler;
+//    private final CustomOAuth2UserService customOAuth2UserService;
+//    private final CustomSuccessHandler customSuccessHandler;
     private final JWTUtil jwtUtil;
 
 
@@ -33,7 +38,6 @@ public class SecurityConfig {
 
 
         //cors
-
         http
                 .cors(corsCustomizer -> corsCustomizer.configurationSource(new CorsConfigurationSource() {
 
@@ -68,18 +72,19 @@ public class SecurityConfig {
                 .httpBasic((auth) -> auth.disable());
         //JWTFilter 추가
         http
-                .addFilterAfter(new JWTFilter(jwtUtil), OAuth2LoginAuthenticationFilter.class);
-        //oauth2
-        http
-                .oauth2Login((oauth2) -> oauth2
-                        .userInfoEndpoint((userInfoEndpointConfig) -> userInfoEndpointConfig
-                                .userService(customOAuth2UserService)).
-                        successHandler(customSuccessHandler));
+                .addFilterBefore(new JWTFilter(jwtUtil), SecurityContextPersistenceFilter.class);
+
+        //oauth2을 더이상 사용하지 않으므로 삭제
+//        http
+//                .oauth2Login((oauth2) -> oauth2
+//                        .userInfoEndpoint((userInfoEndpointConfig) -> userInfoEndpointConfig
+//                                .userService(customOAuth2UserService)).
+//                        successHandler(customSuccessHandler));
 
         //경로별 인가 작업
         http
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/", "/h2-console/**", "/main.html", "/ws", "/oauth2/authorization/kakao").permitAll()
+                        .requestMatchers("/", "/h2-console/**", "/main.html", "/test","/api/v1/login/oauth/kakao","/api/v1/login/oauth/kakao/**").permitAll()
                         .anyRequest().authenticated());
 
         //세션 설정 : STATELESS

--- a/familing/src/main/java/com/pinu/familing/global/config/SecurityConfig.java
+++ b/familing/src/main/java/com/pinu/familing/global/config/SecurityConfig.java
@@ -2,21 +2,15 @@ package com.pinu.familing.global.config;
 
 import com.pinu.familing.global.jwt.JWTFilter;
 import com.pinu.familing.global.jwt.JWTUtil;
-import com.pinu.familing.global.oauth.CustomSuccessHandler;
-import com.pinu.familing.global.oauth.service.CustomOAuth2UserService;
+import com.pinu.familing.global.oauth.service.PrincipalService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.context.SecurityContextPersistenceFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -28,9 +22,8 @@ import java.util.Collections;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-//    private final CustomOAuth2UserService customOAuth2UserService;
-//    private final CustomSuccessHandler customSuccessHandler;
     private final JWTUtil jwtUtil;
+    private final PrincipalService principalService;
 
 
     @Bean
@@ -72,7 +65,7 @@ public class SecurityConfig {
                 .httpBasic((auth) -> auth.disable());
         //JWTFilter 추가
         http
-                .addFilterBefore(new JWTFilter(jwtUtil), SecurityContextPersistenceFilter.class);
+                .addFilterBefore(new JWTFilter(jwtUtil, principalService), SecurityContextPersistenceFilter.class);
 
         //oauth2을 더이상 사용하지 않으므로 삭제
 //        http
@@ -84,7 +77,7 @@ public class SecurityConfig {
         //경로별 인가 작업
         http
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/", "/h2-console/**", "/main.html", "/test","/api/v1/login/oauth/kakao","/api/v1/login/oauth/kakao/**").permitAll()
+                        .requestMatchers("/", "/h2-console/**", "/main.html", "/test", "/api/v1/login/oauth/kakao", "/api/v1/login/oauth/kakao/**").permitAll()
                         .anyRequest().authenticated());
 
         //세션 설정 : STATELESS

--- a/familing/src/main/java/com/pinu/familing/global/jwt/JWTFilter.java
+++ b/familing/src/main/java/com/pinu/familing/global/jwt/JWTFilter.java
@@ -1,7 +1,7 @@
 package com.pinu.familing.global.jwt;
 
-import com.pinu.familing.domain.user.dto.UserDto;
-import com.pinu.familing.global.oauth.dto.CustomOAuth2User;
+import com.pinu.familing.global.oauth.dto.PrincipalDetails;
+import com.pinu.familing.global.oauth.service.PrincipalService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
@@ -9,6 +9,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -17,10 +18,11 @@ import java.io.IOException;
 public class JWTFilter extends OncePerRequestFilter {
 
     private final JWTUtil jwtUtil;
+    private final PrincipalService principalService;
 
-    public JWTFilter(JWTUtil jwtUtil) {
-
+    public JWTFilter(JWTUtil jwtUtil, PrincipalService principalService) {
         this.jwtUtil = jwtUtil;
+        this.principalService = principalService;
     }
 
     @Override
@@ -71,14 +73,12 @@ public class JWTFilter extends OncePerRequestFilter {
         String username = jwtUtil.getUsername(token);
         String role = jwtUtil.getRole(token);
 
-        //userDTO를 생성하여 값 set
-        UserDto userDto = new UserDto(username, null, role);
-
         //UserDetails에 회원 정보 객체 담기
-        CustomOAuth2User customOAuth2User = new CustomOAuth2User(userDto);
+        PrincipalDetails userDetail = (PrincipalDetails) principalService.loadUserByUsername(username);
 
         //스프링 시큐리티 인증 토큰 생성
-        Authentication authToken = new UsernamePasswordAuthenticationToken(customOAuth2User, null, customOAuth2User.getAuthorities());
+        Authentication authToken = new UsernamePasswordAuthenticationToken(userDetail, null, userDetail.getAuthorities());
+
         //세션에 사용자 등록
         SecurityContextHolder.getContext().setAuthentication(authToken);
 

--- a/familing/src/main/java/com/pinu/familing/global/jwt/JWTFilter.java
+++ b/familing/src/main/java/com/pinu/familing/global/jwt/JWTFilter.java
@@ -29,6 +29,12 @@ public class JWTFilter extends OncePerRequestFilter {
         //cookie들을 불러온 뒤 Authorization Key에 담긴 쿠키를 찾음
         String authorization = null;
         Cookie[] cookies = request.getCookies();
+
+        if (cookies == null) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         for (Cookie cookie : cookies) {
 
             System.out.println(cookie.getName());

--- a/familing/src/main/java/com/pinu/familing/global/oauth/CustomSuccessHandler.java
+++ b/familing/src/main/java/com/pinu/familing/global/oauth/CustomSuccessHandler.java
@@ -19,6 +19,8 @@ import java.util.Iterator;
 @Component
 public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
+//    @Value("${server.address}")
+    private String serverIp;
 
     private final JWTUtil jwtUtil;
 

--- a/familing/src/main/java/com/pinu/familing/global/oauth/controller/KakaoController.java
+++ b/familing/src/main/java/com/pinu/familing/global/oauth/controller/KakaoController.java
@@ -19,19 +19,13 @@ public class KakaoController {
 
     //0. 카카오 로그인 화면/api/v1/login/oauth/kakao 보여주기
     @GetMapping("/api/v1/login/oauth/kakao")
-    public void requestKakaoLoginScreen(HttpServletResponse response) throws IOException, IOException {
-        System.out.println(" ================================  ");
-        String url = "https://kauth.kakao.com/oauth/authorize" +
-                "?client_id=" + "a14905b8341b367a459e237b63b373b1" +
-                "&redirect_uri=" + "http://localhost:8080/api/v1/login/oauth/kakao/code" +
-                "&response_type=code";
-        response.sendRedirect(url);
+    public void requestKakaoLoginScreen(HttpServletResponse response) throws IOException {
+        response.sendRedirect(kakaoService.getKakaoLoginUrl());
     }
 
 
     @GetMapping("/api/v1/login/oauth/kakao/code")
     public ApiUtils.ApiResult<?> requestKakaoLoginScreen(@RequestParam(value = "code") String code){
-        System.out.println("!!!!!!!!!!!!!!!!!!!!");
         String accessToken = kakaoService.getKakaoAccessToken(code).accessToken();
         return ApiUtils.success("AccessToken: "+ accessToken);
     }

--- a/familing/src/main/java/com/pinu/familing/global/oauth/controller/KakaoController.java
+++ b/familing/src/main/java/com/pinu/familing/global/oauth/controller/KakaoController.java
@@ -1,0 +1,59 @@
+package com.pinu.familing.global.oauth.controller;
+
+import com.pinu.familing.global.oauth.dto.AccessToken;
+import com.pinu.familing.global.oauth.service.KakaoService;
+import com.pinu.familing.global.util.ApiUtils;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
+
+@RestController
+@RequiredArgsConstructor
+public class KakaoController {
+
+    private final KakaoService kakaoService;
+
+    //0. 카카오 로그인 화면/api/v1/login/oauth/kakao 보여주기
+    @GetMapping("/api/v1/login/oauth/kakao")
+    public void requestKakaoLoginScreen(HttpServletResponse response) throws IOException, IOException {
+        System.out.println(" ================================  ");
+        String url = "https://kauth.kakao.com/oauth/authorize" +
+                "?client_id=" + "a14905b8341b367a459e237b63b373b1" +
+                "&redirect_uri=" + "http://localhost:8080/api/v1/login/oauth/kakao/code" +
+                "&response_type=code";
+        response.sendRedirect(url);
+    }
+
+
+    @GetMapping("/api/v1/login/oauth/kakao/code")
+    public ApiUtils.ApiResult<?> requestKakaoLoginScreen(@RequestParam(value = "code") String code){
+        System.out.println("!!!!!!!!!!!!!!!!!!!!");
+        String accessToken = kakaoService.getKakaoAccessToken(code).accessToken();
+        return ApiUtils.success("AccessToken: "+ accessToken);
+    }
+
+    @PostMapping("/api/v1/login/oauth/kakao/callback")
+    public ApiUtils.ApiResult<?> saveKakaoLoginUser(@RequestBody AccessToken accessToken, HttpSession session, HttpServletResponse response) {
+        String token = kakaoService.saveKakaoLoginUser(accessToken,session);
+        response.addCookie(createCookie("Authorization", token));
+        return ApiUtils.success("Login completed successfully");
+    }
+
+    private Cookie createCookie(String key, String value) {
+
+        Cookie cookie = new Cookie(key, value);
+        cookie.setMaxAge(60 * 60 * 60);
+        // https only
+        //cookie.setSecure(true);
+        //쿠기가 보일 위치
+        cookie.setPath("/");
+        // js가 쿠키를 가져가지 못하게
+        cookie.setHttpOnly(true);
+
+        return cookie;
+    }
+}

--- a/familing/src/main/java/com/pinu/familing/global/oauth/dto/AccessToken.java
+++ b/familing/src/main/java/com/pinu/familing/global/oauth/dto/AccessToken.java
@@ -1,0 +1,8 @@
+package com.pinu.familing.global.oauth.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record AccessToken(String accessToken) {
+}

--- a/familing/src/main/java/com/pinu/familing/global/oauth/dto/KakaoProfileRequest.java
+++ b/familing/src/main/java/com/pinu/familing/global/oauth/dto/KakaoProfileRequest.java
@@ -1,0 +1,16 @@
+package com.pinu.familing.global.oauth.dto;
+
+public record KakaoProfileRequest(Long id, Properties properties) {
+
+    public String username() {
+        return "kakao_" + this.id;
+    }
+
+    public String nickname() {
+        return properties().nickname;
+    }
+
+    record Properties(String nickname) {
+    }
+
+}

--- a/familing/src/main/java/com/pinu/familing/global/oauth/dto/PrincipalDetails.java
+++ b/familing/src/main/java/com/pinu/familing/global/oauth/dto/PrincipalDetails.java
@@ -1,0 +1,63 @@
+package com.pinu.familing.global.oauth.dto;
+
+import com.pinu.familing.domain.user.entity.User;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+@Getter
+public class PrincipalDetails implements UserDetails {
+    private User user; //컴포지션  우리의 유저 엔티티를 이렇게 가지고 있네..? 신기하다... 그러면 앞으로는 이 PrincipalDetail를 이용해서 엔티티에 접근하는건가? 정말 신기하다묭~
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public PrincipalDetails(User user) {
+        this.user = user;
+    }
+    @Override
+    public String getPassword() {
+        return "password";
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getUsername();
+    }
+
+    //계정이 살아있는지 리턴 : ture -> 만료 X / false -> 만료됨
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    //계정이 잠기지 않았는지 리턴 : true -> 잠기지 않음
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    //비밀번호가 만료되지 않았는지 리턴 : ture -> 만료 X
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    //계정이 활성화되어있는지 리턴 : true -> 만료 X
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    //계정의 권한을 리턴...!!
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() { //타입이 특이하군용..?!
+        Collection<GrantedAuthority> collection = new ArrayList<>();
+        collection.add(()-> "ROLE_"+user.getRole());
+        return collection;
+    }
+}

--- a/familing/src/main/java/com/pinu/familing/global/oauth/properties/KakaoProperties.java
+++ b/familing/src/main/java/com/pinu/familing/global/oauth/properties/KakaoProperties.java
@@ -1,0 +1,16 @@
+package com.pinu.familing.global.oauth.properties;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "spring.security.oauth.kakao") //내부적으로 세터를 이용해서 등록하게 한다.
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record KakaoProperties(
+        String authorizationCode,
+        String codeRequestUri,
+        String tokenRequestUri,
+        String redirectUri,
+        String userInfoUri,
+        String clientId) {
+}

--- a/familing/src/main/java/com/pinu/familing/global/oauth/service/KakaoService.java
+++ b/familing/src/main/java/com/pinu/familing/global/oauth/service/KakaoService.java
@@ -1,0 +1,97 @@
+package com.pinu.familing.global.oauth.service;
+
+import com.pinu.familing.domain.user.entity.User;
+import com.pinu.familing.domain.user.repository.UserRepository;
+import com.pinu.familing.global.jwt.JWTUtil;
+import com.pinu.familing.global.oauth.dto.AccessToken;
+import com.pinu.familing.global.oauth.dto.KakaoProfileRequest;
+import com.pinu.familing.global.oauth.dto.PrincipalDetails;
+import com.pinu.familing.global.oauth.properties.KakaoProperties;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+import static io.jsonwebtoken.lang.Strings.UTF_8;
+import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED;
+
+@Service
+public class KakaoService {
+
+    private static final MediaType FORM_URLENCODED = new MediaType(APPLICATION_FORM_URLENCODED, UTF_8);
+    private static final String AUTHORIZATION = "Authorization";
+    private static final String BEARER = "Bearer ";
+
+    private final PrincipalService principalService;
+    private final UserRepository userRepository;
+    private final RestClient restClient;
+    private final KakaoProperties kakaoProperties;
+    private final JWTUtil jwtUtil;
+
+    public KakaoService(PrincipalService principalService, UserRepository userRepository, KakaoProperties kakaoProperties, JWTUtil jwtUtil) {
+        this.principalService = principalService;
+        this.userRepository = userRepository;
+        this.kakaoProperties = kakaoProperties;
+        this.jwtUtil = jwtUtil;
+        this.restClient = RestClient.create();
+    }
+
+
+    public AccessToken getKakaoAccessToken(String code) {
+        MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+        map.add("grant_type", kakaoProperties.authorizationCode());
+        map.add("client_id", kakaoProperties.clientId());
+        map.add("redirect_uri", kakaoProperties.redirectUri());
+        map.add("code", code);
+
+        return restClient.post()
+                .uri(kakaoProperties.tokenRequestUri())
+                .contentType(FORM_URLENCODED)
+                .body(map)
+                .retrieve()
+                .toEntity(AccessToken.class)
+                .getBody();
+    }
+
+    public String saveKakaoLoginUser(AccessToken accessToken, HttpSession session) {
+
+        //엑세스 토큰으로 유저 정보 가져오기
+        KakaoProfileRequest kakaoProfile = restClient.post()
+                .uri(kakaoProperties.userInfoUri())
+                .contentType(FORM_URLENCODED)
+                .header(AUTHORIZATION, BEARER + accessToken.accessToken())
+                .retrieve()
+                .toEntity(KakaoProfileRequest.class)
+                .getBody();
+
+        //유저 정보로 자체 회원 DB에 넣기
+        User user = userRepository.findByUsername(kakaoProfile.username())
+                .orElseGet(() -> {
+                    User newUser = User.builder()
+                            .username(kakaoProfile.username())
+                            .nickname(kakaoProfile.nickname())
+                            .realname(kakaoProfile.nickname())
+                            .role("ROLE_PENDING_USER")
+                            .build();
+                    return userRepository.save(newUser);
+                });
+
+        //강제로 세션에 넣기
+        PrincipalDetails userDetail = (PrincipalDetails) principalService.loadUserByUsername(user.getUsername());
+        Authentication authentication = new UsernamePasswordAuthenticationToken(userDetail, userDetail.getPassword(), userDetail.getAuthorities());
+        SecurityContext securityContext = SecurityContextHolder.getContext();
+        securityContext.setAuthentication(authentication);
+        session.setAttribute("SPRING_SECURITY_CONTEXT", securityContext);
+
+        //jwt 토큰 발급하기
+        String token = jwtUtil.createJwt(userDetail.getUsername(), user.getRole(), 60 * 60 * 60 * 60L);
+        return token;
+    }
+
+}

--- a/familing/src/main/java/com/pinu/familing/global/oauth/service/KakaoService.java
+++ b/familing/src/main/java/com/pinu/familing/global/oauth/service/KakaoService.java
@@ -43,6 +43,13 @@ public class KakaoService {
     }
 
 
+    public String getKakaoLoginUrl() {
+        return  kakaoProperties.codeRequestUri() +
+                "?client_id=" + kakaoProperties.clientId()+
+                "&redirect_uri=" + kakaoProperties.redirectUri() +
+                "&response_type=code";
+    }
+
     public AccessToken getKakaoAccessToken(String code) {
         MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
         map.add("grant_type", kakaoProperties.authorizationCode());
@@ -82,15 +89,9 @@ public class KakaoService {
                     return userRepository.save(newUser);
                 });
 
-        //강제로 세션에 넣기
-        PrincipalDetails userDetail = (PrincipalDetails) principalService.loadUserByUsername(user.getUsername());
-        Authentication authentication = new UsernamePasswordAuthenticationToken(userDetail, userDetail.getPassword(), userDetail.getAuthorities());
-        SecurityContext securityContext = SecurityContextHolder.getContext();
-        securityContext.setAuthentication(authentication);
-        session.setAttribute("SPRING_SECURITY_CONTEXT", securityContext);
 
         //jwt 토큰 발급하기
-        String token = jwtUtil.createJwt(userDetail.getUsername(), user.getRole(), 60 * 60 * 60 * 60L);
+        String token = jwtUtil.createJwt(user.getUsername(), user.getRole(), 60 * 60 * 60 * 60L);
         return token;
     }
 

--- a/familing/src/main/java/com/pinu/familing/global/oauth/service/PrincipalService.java
+++ b/familing/src/main/java/com/pinu/familing/global/oauth/service/PrincipalService.java
@@ -1,0 +1,28 @@
+package com.pinu.familing.global.oauth.service;
+
+import com.pinu.familing.domain.user.entity.User;
+import com.pinu.familing.domain.user.repository.UserRepository;
+import com.pinu.familing.global.error.CustomException;
+import com.pinu.familing.global.error.ExceptionCode;
+import com.pinu.familing.global.oauth.dto.PrincipalDetails;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PrincipalService implements UserDetailsService {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(()-> new CustomException(ExceptionCode.USER_NOT_FOUND));
+        return new PrincipalDetails(user);
+    }
+
+
+}


### PR DESCRIPTION
## 연관 이슈
#48 

## 브랜치
develop -> feat/48-kakao

## 코드 설명
- 안드로이드단에서 엑세스 토큰을 전달해주기때문에, 해당값으로 사용자 정보를 조회 후, 회원가입&로그인 처리 
- Oauth2클라이언트가 아니라 직접 구현 KakaoController와 KakaoService 부분
- Jwt 필터위치 변경 (시큐리티콘피그 파일)

- 세션에 커스텀~이 아니라 프린시펄 타입이 올라가기 때문에 컨트롤러 파라미터 모두 변경
