### PR TITLE
fix: 가족 생성 로직과 유저의 채팅방 입장 로직 분리

### DIFF
--- a/familing/src/main/java/com/pinu/familing/domain/chat/service/ChatService.java
+++ b/familing/src/main/java/com/pinu/familing/domain/chat/service/ChatService.java
@@ -39,7 +39,7 @@ public class ChatService {
     private final UserRepository userRepository;
 
     @Transactional
-    public boolean makeChatRoom(User user, String validCode) {
+    public boolean makeChatRoom(String validCode) {
         if (chatRoomRepository.findByValidCode(validCode).isPresent()) {
             throw new CustomException(CHATROOM_ALREADY_EXISTS);
         }
@@ -49,8 +49,6 @@ public class ChatService {
                 .validCode(validCode)
                 .users(new ArrayList<>())
                 .build();
-        // ChatRoom 객체에 User 추가
-        chatRoom.addUser(user);
         chatRoomRepository.save(chatRoom);
         return true;
     }

--- a/familing/src/main/java/com/pinu/familing/domain/family/service/FamilyService.java
+++ b/familing/src/main/java/com/pinu/familing/domain/family/service/FamilyService.java
@@ -48,7 +48,7 @@ public class FamilyService {
         Family savefamily = familyRepository.save(family);
 
         // 가족 등록할 때 가족 채팅방 가동 생성
-        chatService.makeChatRoom(user, validCode);
+        chatService.makeChatRoom(validCode);
 
         FamilyDto familyDto = FamilyDto.fromEntity(savefamily);
 

--- a/familing/src/main/java/com/pinu/familing/domain/user/service/UserService.java
+++ b/familing/src/main/java/com/pinu/familing/domain/user/service/UserService.java
@@ -1,5 +1,7 @@
 package com.pinu.familing.domain.user.service;
 
+import com.pinu.familing.domain.chat.entity.ChatRoom;
+import com.pinu.familing.domain.chat.repository.ChatRoomRepository;
 import com.pinu.familing.domain.family.entity.Family;
 import com.pinu.familing.domain.family.repository.FamilyRepository;
 import com.pinu.familing.domain.snapshot.service.SnapshotService;
@@ -20,6 +22,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.Optional;
+
 import static com.pinu.familing.global.error.ExceptionCode.USER_NOT_FOUND;
 
 @Service
@@ -31,6 +35,7 @@ public class UserService {
     private final SnapshotService snapshotService;
     private final AwsS3Service awsS3Service;
     private final StatusRepository statusRepository;
+    private final ChatRoomRepository chatRoomRepository;
 
 
     public UserResponse giveUserInformation(String username) {
@@ -49,6 +54,10 @@ public class UserService {
         Family family = familyRepository.findByCode(code)
                 .orElseThrow(() -> new CustomException(ExceptionCode.INVALID_CODE));
 
+        ChatRoom chatRoom = chatRoomRepository.findByValidCode(family.getCode())
+                .orElseThrow(() -> new CustomException(ExceptionCode.CHATROOM_NOT_FOUND));
+
+        chatRoom.addUser(user);
         user.registerFamily(family);
         setDefaultStatusValue(user);
     }

--- a/familing/src/main/java/com/pinu/familing/global/error/ExceptionCode.java
+++ b/familing/src/main/java/com/pinu/familing/global/error/ExceptionCode.java
@@ -16,6 +16,7 @@ public enum ExceptionCode {
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "JWT 토큰이 만료되었습니다."),
     IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "이미지를 찾을 수 없습니다."),
     S3_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "S3에서 이미지를 찾을 수 없습니다."),
+    CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅방을 찾을 수 없습니다."),
 
     // 잘못된 접근
     BAD_APPROACH(HttpStatus.BAD_REQUEST, "잘못된 접근입니다."),

--- a/familing/src/main/resources/data.sql
+++ b/familing/src/main/resources/data.sql
@@ -13,7 +13,7 @@ INSERT INTO status (text)
 VALUES ('쉬는 중');
 
 INSERT INTO snapshot_title (title)
-VALUES ('가장 잘나왔다고 생각하는 셀카');
+VALUES ('가장 잘나온 셀카');
 INSERT INTO snapshot_title (title)
 VALUES ('오늘의 점심메뉴');
 INSERT INTO snapshot_title (title)


### PR DESCRIPTION
## #️⃣연관된 이슈

#61 

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
hot fix/61-chatroom-null -> main

### 변경 사항 설명

가족 생성할 때만 채팅방에 입장하는 로직을
유저가 가족에 등록될 때 채팅방에 입장하는 로직으로 변경했습니다.

### 테스트 결과

<img width="724" alt="스크린샷 2024-08-30 오후 4 04 53" src="https://github.com/user-attachments/assets/735a10ee-b332-4dd2-9304-0bb43877f8fb">
