### PR TITLE
fix: 가족생성할 때 이름이 비어있으면 생성안되게 수정

### DIFF
--- a/familing/src/main/java/com/pinu/familing/domain/family/controller/FamilyController.java
+++ b/familing/src/main/java/com/pinu/familing/domain/family/controller/FamilyController.java
@@ -33,7 +33,7 @@ public class FamilyController {
     public ApiUtils.ApiResult<?> createFamily(@AuthenticationPrincipal PrincipalDetails principalDetails, @RequestBody FamilyName familyName) {
         Map<String, Object> responseBody = new HashMap<>();
         //가족 코드 생성 로직
-        FamilyDto familyDto = familyService.registerNewFamily(principalDetails.getUsername(), familyName.name());
+        FamilyDto familyDto = familyService.registerNewFamily(principalDetails.getUsername(), familyName.familyName());
         //유저에 가족을 넣기
         userService.addFamilyToUser(principalDetails.getUsername(), familyDto.code());
         responseBody.put("code", familyDto.code());

--- a/familing/src/main/java/com/pinu/familing/domain/family/dto/FamilyName.java
+++ b/familing/src/main/java/com/pinu/familing/domain/family/dto/FamilyName.java
@@ -1,6 +1,9 @@
 package com.pinu.familing.domain.family.dto;
 
-import jakarta.validation.constraints.NotNull;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import jakarta.validation.constraints.NotBlank;
 
-public record FamilyName(@NotNull(message = "가족 이름을 설정해 주세요.") String name) {
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record FamilyName(@NotBlank(message = "가족 이름을 설정해 주세요.") String familyName) {
 }

--- a/familing/src/main/java/com/pinu/familing/domain/status/dto/MyFamilyStatusResponse.java
+++ b/familing/src/main/java/com/pinu/familing/domain/status/dto/MyFamilyStatusResponse.java
@@ -23,7 +23,7 @@ public record MyFamilyStatusResponse(UserStatusResponse me,
 
 
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-    private record UserStatusResponse(String username,
+    public record UserStatusResponse(String username,
                                       String nickname,
                                       String imageUrl,
                                       String status) {

--- a/familing/src/test/java/com/pinu/familing/domain/status/service/StatusServiceTest.java
+++ b/familing/src/test/java/com/pinu/familing/domain/status/service/StatusServiceTest.java
@@ -4,12 +4,15 @@ import com.pinu.familing.IntegrationTestSupport;
 import com.pinu.familing.domain.family.entity.Family;
 import com.pinu.familing.domain.family.repository.FamilyRepository;
 import com.pinu.familing.domain.status.dto.MyFamilyStatusResponse;
+import com.pinu.familing.domain.status.dto.StatusResponse;
 import com.pinu.familing.domain.user.entity.User;
 import com.pinu.familing.domain.user.repository.UserRepository;
 import com.pinu.familing.domain.status.dto.StatusRequest;
 import com.pinu.familing.domain.status.entity.Status;
 import com.pinu.familing.domain.status.repository.StatusRepository;
 import jakarta.persistence.EntityManager;
+import org.aspectj.lang.annotation.After;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,110 +22,89 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-
 class StatusServiceTest extends IntegrationTestSupport {
 
-    private final StatusService statusService;
-    private final UserRepository userRepository;
-    private final StatusRepository statusRepository;
-    private final FamilyRepository familyRepository;
-    private final EntityManager entityManager;
-
     @Autowired
-    StatusServiceTest(StatusService StatusService,
-                      UserRepository userRepository,
-                      StatusRepository StatusRepository,
-                      FamilyRepository familyRepository,
-                      EntityManager entityManager) {
-        this.statusService = StatusService;
-        this.userRepository = userRepository;
-        this.statusRepository = StatusRepository;
-        this.familyRepository = familyRepository;
-        this.entityManager = entityManager;
-    }
+    private StatusService statusService;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private StatusRepository statusRepository;
+    @Autowired
+    private FamilyRepository familyRepository;
+    @Autowired
+    private EntityManager entityManager;
 
     @BeforeEach
     public void setUp() {
-        statusRepository.save(Status.builder().text("공부 중").build());
-        statusRepository.save(Status.builder().text("노는 중").build());
-        statusRepository.save(Status.builder().text("쉬는 중").build());
-        statusRepository.save(Status.builder().text("일하는 중").build());
-
-        User user1 = userRepository.save(
-                User.builder()
-                        .username("user1")
-                        .nickname("유저1").build());
-
-
-        User user2 = userRepository.save(
-                User.builder()
-                        .username("user2")
-                        .nickname("유저2").build());
+        statusRepository.saveAll(List.of(
+                Status.builder().text("공부 중").build(),
+                Status.builder().text("노는 중").build(),
+                Status.builder().text("쉬는 중").build(),
+                Status.builder().text("일하는 중").build()
+        ));
 
         Family family = familyRepository.save(new Family("가족", "code"));
 
-        user1.registerFamily(family);
-        user2.registerFamily(family);
+        User user1 = userRepository.save(User.builder()
+                .username("user1")
+                .nickname("유저1")
+                .family(family)
+                .build());
+
+        User user2 = userRepository.save(User.builder()
+                .username("user2")
+                .nickname("유저2")
+                .family(family)
+                .build());
 
         entityManager.flush();
         entityManager.clear();
-
     }
 
-
+    @AfterEach
+    public void tearDown() {
+        statusRepository.deleteAll();
+        userRepository.deleteAll();
+        familyRepository.deleteAll();
+    }
 
     @Test
-    @DisplayName("상태리스트조회 메서드 테스트")
+    @DisplayName("상태 리스트 조회 메서드 테스트")
     @Transactional
     void getStatusListTest() {
-        //give
-        //when
-        List<?> StatusList =statusService.getStatusList();
-        //then
-        assertThat(StatusList.size()).isEqualTo(4);
-        System.out.println("StatusList = " + StatusList);
+        List<StatusResponse> statusList = statusService.getStatusList();
+        assertThat(statusList).hasSize(4);
     }
 
     @Test
-    @DisplayName("유저의 상태 변경되는지 테스트")
+    @DisplayName("유저의 상태 변경 테스트")
     @Transactional
     void changeStatusTest() {
-        entityManager.clear();
-        //give
         StatusRequest statusRequest = new StatusRequest(statusRepository.findByText("쉬는 중").get().getId());
-        //when
         statusService.changeUserStatus("user1", statusRequest);
-        //then
         assertThat(userRepository.findByUsername("user1").get().getStatus().getText()).isEqualTo("쉬는 중");
-
     }
 
     @Test
-    @DisplayName("유저 기준 가족의 상태조회")
+    @DisplayName("유저 기준 가족의 상태 조회")
     @Transactional
     void getFamilyStatusListTest() {
-        //give
-        Status status1 = statusRepository.findByText("공부 중").get();
+
+
+        //given
         User user1 = userRepository.findByUsername("user1").get();
-        user1.changeStatus(status1);
-
-        userRepository.save(user1);
-
-        System.out.println("user1.getFamily().getUsers() = " + user1.getFamily().getUsers());
-
-        Status status2 = statusRepository.findByText("노는 중").get();
         User user2 = userRepository.findByUsername("user2").get();
-        user2.changeStatus(status2);
 
-        userRepository.save(user2);
+        StatusRequest statusRequest1 = new StatusRequest(statusRepository.findByText("쉬는 중").get().getId());
+        StatusRequest statusRequest2 = new StatusRequest(statusRepository.findByText("노는 중").get().getId());
 
-        System.out.println("user2 = " + user2.getFamily());
+        entityManager.flush();
         //when
-        MyFamilyStatusResponse myFamilyStatusResponse = statusService.getFamilyStatusList("user1");
-
+        statusService.changeUserStatus("user1", statusRequest1);
+        statusService.changeUserStatus("user2", statusRequest2);
         //then
-        System.out.println("myFamilyStatusResponse = " + myFamilyStatusResponse);
-
+        MyFamilyStatusResponse response = statusService.getFamilyStatusList("user1");
+        assertThat(response.family().get(0).status()).isEqualTo("노는 중");
     }
-
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#65 

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
bug/65-database -> develop

### 변경 사항 설명
yml파일로 테스트 데이터베이스 분리와, 가족생성할 때 가족 이름이 비어있으면 생성안되게 수정