### PR TITLE
애정카드 전송을 위한 가족 username 조회 가능 + 가족 생성시 이름 비어있지 못하게 예외 처리 + 테스트 데이터베이스 분리

### DIFF
--- a/familing/src/main/java/com/pinu/familing/domain/family/controller/FamilyController.java
+++ b/familing/src/main/java/com/pinu/familing/domain/family/controller/FamilyController.java
@@ -33,7 +33,7 @@ public class FamilyController {
     public ApiUtils.ApiResult<?> createFamily(@AuthenticationPrincipal PrincipalDetails principalDetails, @RequestBody FamilyName familyName) {
         Map<String, Object> responseBody = new HashMap<>();
         //가족 코드 생성 로직
-        FamilyDto familyDto = familyService.registerNewFamily(principalDetails.getUsername(), familyName.name());
+        FamilyDto familyDto = familyService.registerNewFamily(principalDetails.getUsername(), familyName.familyName());
         //유저에 가족을 넣기
         userService.addFamilyToUser(principalDetails.getUsername(), familyDto.code());
         responseBody.put("code", familyDto.code());

--- a/familing/src/main/java/com/pinu/familing/domain/family/dto/FamilyName.java
+++ b/familing/src/main/java/com/pinu/familing/domain/family/dto/FamilyName.java
@@ -1,6 +1,9 @@
 package com.pinu.familing.domain.family.dto;
 
-import jakarta.validation.constraints.NotNull;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import jakarta.validation.constraints.NotBlank;
 
-public record FamilyName(@NotNull(message = "가족 이름을 설정해 주세요.") String name) {
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record FamilyName(@NotBlank(message = "가족 이름을 설정해 주세요.") String familyName) {
 }

--- a/familing/src/main/java/com/pinu/familing/domain/family/dto/FamilyUserDto.java
+++ b/familing/src/main/java/com/pinu/familing/domain/family/dto/FamilyUserDto.java
@@ -2,6 +2,7 @@ package com.pinu.familing.domain.family.dto;
 
 public record FamilyUserDto(
         String nickName,
-        String profileImg
+        String profileImg,
+        String username
 ) {
 }

--- a/familing/src/main/java/com/pinu/familing/domain/family/dto/FamilyUsersDto.java
+++ b/familing/src/main/java/com/pinu/familing/domain/family/dto/FamilyUsersDto.java
@@ -1,17 +1,20 @@
 package com.pinu.familing.domain.family.dto;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.pinu.familing.domain.user.entity.User;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record FamilyUsersDto(
     List<FamilyUserDto> familyUserDtoList
 ) {
 
     public static FamilyUsersDto fromEntity(List<User> users){
         return new FamilyUsersDto(users.stream()
-                .map(user -> new FamilyUserDto(user.getNickname(), user.getProfileImg()))
+                .map(user -> new FamilyUserDto(user.getNickname(), user.getProfileImg(), user.getUsername()))
                 .toList());
     }
 }

--- a/familing/src/main/java/com/pinu/familing/domain/family/dto/MyFamilyDto.java
+++ b/familing/src/main/java/com/pinu/familing/domain/family/dto/MyFamilyDto.java
@@ -1,9 +1,12 @@
 package com.pinu.familing.domain.family.dto;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.pinu.familing.domain.family.entity.Family;
 import lombok.Builder;
 
 @Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record MyFamilyDto(Long id,
                           String familyName,
                           String code,

--- a/familing/src/main/java/com/pinu/familing/domain/status/dto/MyFamilyStatusResponse.java
+++ b/familing/src/main/java/com/pinu/familing/domain/status/dto/MyFamilyStatusResponse.java
@@ -23,7 +23,7 @@ public record MyFamilyStatusResponse(UserStatusResponse me,
 
 
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-    private record UserStatusResponse(String username,
+    public record UserStatusResponse(String username,
                                       String nickname,
                                       String imageUrl,
                                       String status) {

--- a/familing/src/main/resources/data.sql
+++ b/familing/src/main/resources/data.sql
@@ -35,26 +35,26 @@ VALUES ('나의 휴식 공간');
 
 
 INSERT INTO lovecard (image)
-VALUES ('이미지1');
+VALUES ('https://familing-bucket.s3.ap-northeast-2.amazonaws.com/lovecard1.png');
 INSERT INTO lovecard (image)
-VALUES ('이미지2');
+VALUES ('https://familing-bucket.s3.ap-northeast-2.amazonaws.com/lovecard2.png');
 INSERT INTO lovecard (image)
-VALUES ('이미지3');
+VALUES ('https://familing-bucket.s3.ap-northeast-2.amazonaws.com/lovecard3.png');
 INSERT INTO lovecard (image)
-VALUES ('이미지4');
+VALUES ('https://familing-bucket.s3.ap-northeast-2.amazonaws.com/lovecard4.png');
 INSERT INTO lovecard (image)
-VALUES ('이미지5');
+VALUES ('https://familing-bucket.s3.ap-northeast-2.amazonaws.com/lovecard5.png');
 INSERT INTO lovecard (image)
-VALUES ('이미지6');
+VALUES ('https://familing-bucket.s3.ap-northeast-2.amazonaws.com/lovecard6.png');
 INSERT INTO lovecard (image)
-VALUES ('이미지7');
+VALUES ('https://familing-bucket.s3.ap-northeast-2.amazonaws.com/lovecard7.png');
 INSERT INTO lovecard (image)
-VALUES ('이미지8');
+VALUES ('https://familing-bucket.s3.ap-northeast-2.amazonaws.com/lovecard8.png');
 INSERT INTO lovecard (image)
-VALUES ('이미지9');
+VALUES ('https://familing-bucket.s3.ap-northeast-2.amazonaws.com/lovecard9.png');
 INSERT INTO lovecard (image)
-VALUES ('이미지10');
+VALUES ('https://familing-bucket.s3.ap-northeast-2.amazonaws.com/lovecard10.png');
 INSERT INTO lovecard (image)
-VALUES ('이미지11');
+VALUES ('https://familing-bucket.s3.ap-northeast-2.amazonaws.com/lovecard11.png');
 INSERT INTO lovecard (image)
-VALUES ('이미지12');
+VALUES ('https://familing-bucket.s3.ap-northeast-2.amazonaws.com/lovecard12.png');

--- a/familing/src/test/java/com/pinu/familing/domain/status/service/StatusServiceTest.java
+++ b/familing/src/test/java/com/pinu/familing/domain/status/service/StatusServiceTest.java
@@ -4,12 +4,15 @@ import com.pinu.familing.IntegrationTestSupport;
 import com.pinu.familing.domain.family.entity.Family;
 import com.pinu.familing.domain.family.repository.FamilyRepository;
 import com.pinu.familing.domain.status.dto.MyFamilyStatusResponse;
+import com.pinu.familing.domain.status.dto.StatusResponse;
 import com.pinu.familing.domain.user.entity.User;
 import com.pinu.familing.domain.user.repository.UserRepository;
 import com.pinu.familing.domain.status.dto.StatusRequest;
 import com.pinu.familing.domain.status.entity.Status;
 import com.pinu.familing.domain.status.repository.StatusRepository;
 import jakarta.persistence.EntityManager;
+import org.aspectj.lang.annotation.After;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,110 +22,89 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-
 class StatusServiceTest extends IntegrationTestSupport {
 
-    private final StatusService statusService;
-    private final UserRepository userRepository;
-    private final StatusRepository statusRepository;
-    private final FamilyRepository familyRepository;
-    private final EntityManager entityManager;
-
     @Autowired
-    StatusServiceTest(StatusService StatusService,
-                      UserRepository userRepository,
-                      StatusRepository StatusRepository,
-                      FamilyRepository familyRepository,
-                      EntityManager entityManager) {
-        this.statusService = StatusService;
-        this.userRepository = userRepository;
-        this.statusRepository = StatusRepository;
-        this.familyRepository = familyRepository;
-        this.entityManager = entityManager;
-    }
+    private StatusService statusService;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private StatusRepository statusRepository;
+    @Autowired
+    private FamilyRepository familyRepository;
+    @Autowired
+    private EntityManager entityManager;
 
     @BeforeEach
     public void setUp() {
-        statusRepository.save(Status.builder().text("공부 중").build());
-        statusRepository.save(Status.builder().text("노는 중").build());
-        statusRepository.save(Status.builder().text("쉬는 중").build());
-        statusRepository.save(Status.builder().text("일하는 중").build());
-
-        User user1 = userRepository.save(
-                User.builder()
-                        .username("user1")
-                        .nickname("유저1").build());
-
-
-        User user2 = userRepository.save(
-                User.builder()
-                        .username("user2")
-                        .nickname("유저2").build());
+        statusRepository.saveAll(List.of(
+                Status.builder().text("공부 중").build(),
+                Status.builder().text("노는 중").build(),
+                Status.builder().text("쉬는 중").build(),
+                Status.builder().text("일하는 중").build()
+        ));
 
         Family family = familyRepository.save(new Family("가족", "code"));
 
-        user1.registerFamily(family);
-        user2.registerFamily(family);
+        User user1 = userRepository.save(User.builder()
+                .username("user1")
+                .nickname("유저1")
+                .family(family)
+                .build());
+
+        User user2 = userRepository.save(User.builder()
+                .username("user2")
+                .nickname("유저2")
+                .family(family)
+                .build());
 
         entityManager.flush();
         entityManager.clear();
-
     }
 
-
+    @AfterEach
+    public void tearDown() {
+        statusRepository.deleteAll();
+        userRepository.deleteAll();
+        familyRepository.deleteAll();
+    }
 
     @Test
-    @DisplayName("상태리스트조회 메서드 테스트")
+    @DisplayName("상태 리스트 조회 메서드 테스트")
     @Transactional
     void getStatusListTest() {
-        //give
-        //when
-        List<?> StatusList =statusService.getStatusList();
-        //then
-        assertThat(StatusList.size()).isEqualTo(4);
-        System.out.println("StatusList = " + StatusList);
+        List<StatusResponse> statusList = statusService.getStatusList();
+        assertThat(statusList).hasSize(4);
     }
 
     @Test
-    @DisplayName("유저의 상태 변경되는지 테스트")
+    @DisplayName("유저의 상태 변경 테스트")
     @Transactional
     void changeStatusTest() {
-        entityManager.clear();
-        //give
         StatusRequest statusRequest = new StatusRequest(statusRepository.findByText("쉬는 중").get().getId());
-        //when
         statusService.changeUserStatus("user1", statusRequest);
-        //then
         assertThat(userRepository.findByUsername("user1").get().getStatus().getText()).isEqualTo("쉬는 중");
-
     }
 
     @Test
-    @DisplayName("유저 기준 가족의 상태조회")
+    @DisplayName("유저 기준 가족의 상태 조회")
     @Transactional
     void getFamilyStatusListTest() {
-        //give
-        Status status1 = statusRepository.findByText("공부 중").get();
+
+
+        //given
         User user1 = userRepository.findByUsername("user1").get();
-        user1.changeStatus(status1);
-
-        userRepository.save(user1);
-
-        System.out.println("user1.getFamily().getUsers() = " + user1.getFamily().getUsers());
-
-        Status status2 = statusRepository.findByText("노는 중").get();
         User user2 = userRepository.findByUsername("user2").get();
-        user2.changeStatus(status2);
 
-        userRepository.save(user2);
+        StatusRequest statusRequest1 = new StatusRequest(statusRepository.findByText("쉬는 중").get().getId());
+        StatusRequest statusRequest2 = new StatusRequest(statusRepository.findByText("노는 중").get().getId());
 
-        System.out.println("user2 = " + user2.getFamily());
+        entityManager.flush();
         //when
-        MyFamilyStatusResponse myFamilyStatusResponse = statusService.getFamilyStatusList("user1");
-
+        statusService.changeUserStatus("user1", statusRequest1);
+        statusService.changeUserStatus("user2", statusRequest2);
         //then
-        System.out.println("myFamilyStatusResponse = " + myFamilyStatusResponse);
-
+        MyFamilyStatusResponse response = statusService.getFamilyStatusList("user1");
+        assertThat(response.family().get(0).status()).isEqualTo("노는 중");
     }
-
 }

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2,23 +2,23 @@
 BUILD_JAR=$(ls /home/ubuntu/action/familing/build/libs/familing-0.0.1-SNAPSHOT.jar)
 JAR_NAME=$(basename $BUILD_JAR)
 
-echo "> 현재 시간: $(date)"
+echo "> 현재 시간: $(date)" >> /home/ubuntu/action/deploy.log
 
-echo "> build 파일명: $JAR_NAME"
+echo "> build 파일명: $JAR_NAME" >> /home/ubuntu/action/deploy.log
 
-echo "> build 파일 복사"
+echo "> build 파일 복사" >> /home/ubuntu/action/deploy.log
 DEPLOY_PATH=/home/ubuntu/action/
 cp $BUILD_JAR $DEPLOY_PATH
 
-echo "> 현재 실행중인 애플리케이션 pid 확인"
+echo "> 현재 실행중인 애플리케이션 pid 확인" >> /home/ubuntu/action/deploy.log
 CURRENT_PIDS=$(pgrep -f "java -jar /home/ubuntu/action/$JAR_NAME" | head -n 1)
-echo $CURRENT_PIDS
+echo $CURRENT_PIDS >> /home/ubuntu/action/deploy.log
 
 if [ -z "$CURRENT_PIDS" ]
 then
-  echo "> 현재 구동중인 애플리케이션이 없으므로 종료하지 않습니다."
+  echo "> 현재 구동중인 애플리케이션이 없으므로 종료하지 않습니다." >> /home/ubuntu/action/deploy.log
 else
-  echo "> kill -9 $CURRENT_PIDS"
+  echo "> kill -9 $CURRENT_PIDS" >> /home/ubuntu/action/deploy.log
   sudo kill -9 $CURRENT_PIDS
   sleep 5
 fi


### PR DESCRIPTION
## #️⃣연관된 이슈

#65  #63 

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
develop -> main

### 변경 사항 설명
애정카드 전송을 위한 가족 username 조회 가능 + 가족 생성시 이름 비어있지 못하게 예외 처리 + 테스트 데이터베이스 분리

### 테스트 결과

<img width="712" alt="스크린샷 2024-08-31 오후 4 19 10" src="https://github.com/user-attachments/assets/110cf490-1b36-4293-8809-9ca49100aa6f">
