### PR TITLE
Hotfix/74 gpt response 토큰을 제한해서 gpt의 응답 길이 제한

### DIFF
--- a/familing/src/main/java/com/pinu/familing/domain/gpt/dto/ChatGptRequest.java
+++ b/familing/src/main/java/com/pinu/familing/domain/gpt/dto/ChatGptRequest.java
@@ -9,11 +9,23 @@ import java.util.List;
 public class ChatGptRequest {
     private String model;
     private List<GptRequestMessage> messages;
+    private double temperature;
+    private int max_tokens;
+    private double top_p;
+    private double frequency_penalty;
+    private double presence_penalty;
 
     public ChatGptRequest(String model, String message) {
         this.model = model;
         this.messages = new ArrayList<>();
-        List<Object> list = List.of(new Prompt("text",message), new Prompt("text", " 위 메시지를 가족끼리 사용하는 애정 표현으로 만들어 줘"));
+        this.temperature = 1.0;
+        this.max_tokens = 40;
+        this.top_p = 1.0;
+        this.frequency_penalty = 0.0;
+        this.presence_penalty = 0.0;
+
+        List<Object> list = List.of(new Prompt("text",message), new Prompt("text", " 위 메시지를 가족끼리 사용하는 애정 표현 하나만 만들어서 반환해줘 설명은 필요없어"));
         this.messages.add(new GptRequestMessage("user", list));
+
     }
 }

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+
+echo "> 스크립트 시작" >> /home/ubuntu/action/deploy.log
 BUILD_JAR=$(ls /home/ubuntu/action/familing/build/libs/familing-0.0.1-SNAPSHOT.jar)
 JAR_NAME=$(basename $BUILD_JAR)
 


### PR DESCRIPTION
## #️⃣연관된 이슈

#74 

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
hotfix/74-gpt-reponse -> main

### 변경 사항 설명
토큰을 제한해서 gpt의 응답 길이를 제한했습니다.

### 테스트

<img width="1002" alt="스크린샷 2024-09-02 오후 1 55 54" src="https://github.com/user-attachments/assets/31f05687-4437-4fcb-b24d-8edc7c9f0de4">
