### PR TITLE
스냅샷 오류 수정 배포 (새로운 유저 가족에 들어올 때 null 반환)

### DIFF
--- a/familing/src/main/java/com/pinu/familing/domain/status/controller/StatusController.java
+++ b/familing/src/main/java/com/pinu/familing/domain/status/controller/StatusController.java
@@ -7,10 +7,7 @@ import com.pinu.familing.global.oauth.dto.PrincipalDetails;
 import com.pinu.familing.global.util.ApiUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -28,7 +25,7 @@ public class StatusController {
     //유저의 상태 변경
     @PatchMapping("/users")
     public ApiUtils.ApiResult<?> changeUserStatus(@AuthenticationPrincipal PrincipalDetails principalDetails,
-                                                  StatusRequest statusRequest) {
+                                                  @RequestBody StatusRequest statusRequest) {
         statusService.changeUserStatus(principalDetails.getUsername(), statusRequest);
         return ApiUtils.success("User's status has been successfully changed.");
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

#82 #83 

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
develop -> main

### 변경 사항 설명

스냅샷 오류 수정 배포 (새로운 유저 가족에 들어올 때 null 반환)를 수정해 새로운 유저가 가족에 들어오면 스냅샷 이미지를 추가하도록 수정햇습니다.